### PR TITLE
Volumepfad soll nicht die PH Instanz enthalten

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN chmod a+x /opt/bin/*.py
 COPY secret/etd.conf /opt/etc/
 COPY secret/certificates.pem /opt/etc/
 
-VOLUME /opt/data/out/PH08
+VOLUME /opt/data
 VOLUME /opt/etc
 
  


### PR DESCRIPTION
Volume soll allgemein gehalten werden und die Software soll anhand der konfigurierten AD-Instanz ein Verzeichnis anlegen.